### PR TITLE
Add two-step gesture recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Features
 
-- **Customizable Mouse Gestures**: Currently, navigation is performed using right-click mouse gestures to move forward, backward, or scroll up/down. 
+- **Customizable Mouse Gestures**: Navigate with right-click gestures. Two-step gestures like `down+left` or `up+right` are supported by default.
 - **Visual Feedback**: Gesture actions are visually represented on the screen with smooth animations.
 - **Draw-on-Screen**: As you perform gestures, see your mouse movements tracked like a pencil on the screen, providing clear visual feedback.
 - **Flexible Gesture Settings**: Currently, gestures are fixed, but plans are in place for customizable gestures in future updates, allowing users to personalize their experience.
@@ -32,4 +32,4 @@ Once installed, simply hold the **right mouse button** and move your mouse in th
 
 ### Development Plans
 
-We are working on introducing support for more diverse mouse gestures and allowing users to fully customize which actions are triggered by specific gestures. Stay tuned for updates that will make navigation even more flexible and powerful!
+Two-step gesture support is now included. Future updates will focus on allowing users to fully customize which actions are triggered by each gesture.

--- a/main.ts
+++ b/main.ts
@@ -1,507 +1,165 @@
-import {
-	App,
-	View,
-	MarkdownView,
-	// Notice,
-	Menu,
-	Plugin,
-	PluginSettingTab,
-	Setting,
-	Notice,
-} from 'obsidian';
+import { App, MarkdownView, Plugin, PluginSettingTab, Setting } from 'obsidian';
+import GestureRecognizer, { Gesture } from './src/gesture/GestureRecognizer';
+import GestureActionMap from './src/gesture/GestureActionMap';
+import ObsidianActions from './src/actions/ObsidianActions';
 
 interface GestureNavSettings {
-	trigerkey: TrigerKey;
-	enableDrawing: boolean;
-	strokeColor: string; 
-	customStrokeColor: string; 
-	lineWidth: number;   
-}
-
-enum TrigerKey {
-	RIGHT_CLICK = 2,
-	WHEEL_CLICK = 1,
+  trigerkey: number;
+  enableDrawing: boolean;
+  strokeColor: string;
+  customStrokeColor: string;
+  lineWidth: number;
 }
 
 const DEFAULT_SETTINGS: GestureNavSettings = {
-	trigerkey: TrigerKey.RIGHT_CLICK,
-	enableDrawing: true, 
-	strokeColor: 'accent', 
-	customStrokeColor: '', 
-	lineWidth: 5,          
+  trigerkey: 2,
+  enableDrawing: true,
+  strokeColor: 'accent',
+  customStrokeColor: '',
+  lineWidth: 5,
 };
-
-const isPreviewMode = (markdownView: MarkdownView) => {
-	if (markdownView === null) return false;
-	const mode = markdownView.getMode();
-	return mode === 'preview' && markdownView.previewMode !== null;
-};
-
-const isEditMode = (markdownView: MarkdownView) => {
-	if (markdownView === null) return false;
-	const mode = markdownView.getMode();
-	return mode === 'source' && markdownView.editor !== null;
-};
-
-let globalMarkdownView: MarkdownView | null = null;
-let globalMouseDown = false;
 
 export default class GestureNav extends Plugin {
-	settings: GestureNavSettings;
+  settings: GestureNavSettings;
+  private recognizer = new GestureRecognizer();
+  private actionMap = new GestureActionMap(new ObsidianActions(this.app));
 
-	async onload() {
-		await this.loadSettings();
+  private canvas: HTMLCanvasElement | null = null;
+  private ctx: CanvasRenderingContext2D | null = null;
+  private drawing = false;
 
-		this.registerEvent(
-			this.app.workspace.on('window-open', (newWindow: WorkspaceWindow) =>
-				this.registerEvents(newWindow.win),
-			),
-		);
-		this.registerEvents(window);
+  async onload() {
+    await this.loadSettings();
+    this.actionMap = new GestureActionMap(new ObsidianActions(this.app));
+    this.registerEvents(window);
+    this.addSettingTab(new GestureNavSettingTab(this.app, this));
+  }
 
-		this.addSettingTab(new GestureNavSettingTab(this.app, this));
-	}
+  onunload() {
+    if (this.canvas) document.body.removeChild(this.canvas);
+    this.canvas = null;
+    this.ctx = null;
+  }
 
-	onunload() {
-		// Remove the canvas if it exists
-		if (this.canvas) {
-			document.body.removeChild(this.canvas);
-			this.canvas = null;
-			this.ctx = null;
-		}
+  private registerEvents(currentWindow: Window) {
+    const doc = currentWindow.document;
+    doc.addEventListener('mousedown', (evt) => {
+      if (evt.button === this.settings.trigerkey) {
+        this.recognizer.start(evt.clientX, evt.clientY);
+        this.startDrawing(evt);
+      }
+    });
 
-		// Remove the overlay if it exists
-		if (this.overlay) {
-			this.overlay.remove();
-			this.overlay = null;
-		}
+    doc.addEventListener('mousemove', (evt) => {
+      if (this.drawing) {
+        this.draw(evt.clientX, evt.clientY);
+        this.recognizer.addPoint(evt.clientX, evt.clientY);
+      }
+    });
 
-		// Reset drawing state
-		this.drawing = false;
-	}
+    doc.addEventListener('mouseup', (evt) => {
+      if (evt.button === this.settings.trigerkey) {
+        this.stopDrawing();
+        const gesture = this.recognizer.end();
+        this.actionMap.execute(gesture);
+        this.showGestureOverlay(gesture);
+      }
+    });
+  }
 
-	async loadSettings() {
-		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			await this.loadData(),
-		);
-	}
+  private startDrawing(evt: MouseEvent) {
+    if (!this.settings.enableDrawing) return;
+    this.drawing = true;
+    if (!this.canvas) {
+      this.canvas = document.createElement('canvas');
+      this.canvas.classList.add('gesture-canvas');
+      this.canvas.width = window.innerWidth;
+      this.canvas.height = window.innerHeight;
+      document.body.appendChild(this.canvas);
+      this.ctx = this.canvas.getContext('2d') as CanvasRenderingContext2D;
+      let strokeColor = this.settings.strokeColor;
+      if (strokeColor === 'accent') {
+        const styles = getComputedStyle(document.body);
+        strokeColor = styles.getPropertyValue('--interactive-accent').trim();
+      } else if (strokeColor === 'custom') {
+        strokeColor = this.settings.customStrokeColor || '#000000';
+      }
+      if (this.ctx) {
+        this.ctx.strokeStyle = strokeColor;
+        this.ctx.lineWidth = this.settings.lineWidth;
+        this.ctx.lineJoin = 'round';
+        this.ctx.lineCap = 'round';
+      }
+    }
+    if (this.ctx) {
+      this.ctx.beginPath();
+      this.ctx.moveTo(evt.clientX, evt.clientY);
+    }
+  }
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
+  private draw(x: number, y: number) {
+    if (!this.drawing || !this.ctx) return;
+    this.ctx.lineTo(x, y);
+    this.ctx.stroke();
+  }
 
-	private overlay: HTMLElement | null = null; // Declare overlay at the class level
-	private currentGesture: 'left' | 'right' | 'up' | 'down' | null = null; // Declare currentGesture at the class level
+  private stopDrawing() {
+    this.drawing = false;
+    if (this.canvas) {
+      document.body.removeChild(this.canvas);
+      this.canvas = null;
+      this.ctx = null;
+    }
+  }
 
-	private canvas: HTMLCanvasElement | null = null;
-	private ctx: CanvasRenderingContext2D | null = null;
-	private drawing = false; // Keep track if we are currently drawing
+  private showGestureOverlay(gesture: Gesture | null) {
+    if (!gesture) return;
+    const overlay = document.createElement('div');
+    overlay.classList.add('gesture-overlay');
+    overlay.innerText = gesture;
+    document.body.appendChild(overlay);
+    setTimeout(() => overlay.remove(), 700);
+  }
 
-	private registerEvents(currentWindow: Window) {
-		const doc: Document = currentWindow.document;
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
 
-		// Prevent default right-click context menu
-		function preventDefault(event) {
-			const target = event.target as HTMLElement;
-			if (target.closest('.workspace-leaf')?.classList.contains('nav-folder')) {
-				return;
-			}		
-			if (event.isTrusted) {
-				event.preventDefault();
-				event.stopPropagation();
-			}
-		}
-		// doc.addEventListener('contextmenu', preventDefault, true);
-
-		let startClientX = 0;
-		let startClientY = 0;
-		const gesture_margin = 75;
-
-		// Detect when the right mouse button is pressed
-		this.registerDomEvent(doc, 'mousedown', (evt: MouseEvent) => {
-			if (this.isSettingsVisible()) {
-				return;
-			}
-			if (evt.button === this.settings.trigerkey) {
-				if (isEditMode(this.getCurrentViewOfType())) {
-					doc.addEventListener('contextmenu', preventDefault, true);
-					this.startDrawing(evt);
-					globalMouseDown = true;
-					startClientX = evt.clientX;
-					startClientY = evt.clientY;
-					this.currentGesture = null; // Reset the gesture
-				} else {
-					doc.removeEventListener('contextmenu', preventDefault, true);
-				}
-			}
-		});
-
-		// Track mouse movement to detect gestures, but do not execute actions yet
-		this.registerDomEvent(doc, 'mousemove', (evt: MouseEvent) => {
-			if (this.drawing) {
-				this.draw(evt.clientX, evt.clientY);
-			}
-			if (globalMouseDown) {
-				const deltaX = evt.clientX - startClientX;
-				const deltaY = evt.clientY - startClientY;
-				let detectedGesture: 'left' | 'right' | 'up' | 'down' | null =
-					null;
-
-				// Detect horizontal gestures (left/right)
-				if (
-					Math.abs(deltaX) > gesture_margin &&
-					Math.abs(deltaY) < gesture_margin
-				) {
-					detectedGesture = deltaX > 0 ? 'right' : 'left';
-				}
-				// Detect vertical gestures (up/down)
-				else if (
-					Math.abs(deltaY) > gesture_margin &&
-					Math.abs(deltaX) < gesture_margin
-				) {
-					detectedGesture = deltaY > 0 ? 'down' : 'up';
-				}
-
-				// If gesture has changed, update the overlay
-				if (detectedGesture !== this.currentGesture) {
-					this.currentGesture = detectedGesture;
-					this.showGestureOverlay(this.currentGesture); // Update overlay with the new gesture
-				}
-			}
-		});
-
-		// When the right mouse button is released, execute the corresponding gesture action
-		this.registerDomEvent(doc, 'mouseup', (evt: MouseEvent) => {
-			this.stopDrawing();
-			if (evt.button === this.settings.trigerkey) {
-				globalMouseDown = false;
-				// new Notice('Right Mouse Key UP!! Position: ' + evt.clientX + ' ' + evt.clientY);
-
-				// Execute actions based on the detected gesture
-				if (this.currentGesture === 'right') {
-					this.executeGestureAction('right', () =>
-						window.history.forward(),
-					);
-				} else if (this.currentGesture === 'left') {
-					this.executeGestureAction('left', () =>
-						window.history.back(),
-					);
-				} else if (this.currentGesture === 'down') {
-					this.executeGestureAction(
-						'down',
-						this.scrollToBottom.bind(this),
-					);
-				} else if (this.currentGesture === 'up') {
-					this.executeGestureAction(
-						'up',
-						this.scrollToTop.bind(this),
-					);
-				} else {
-					// this.selectTextUnderCursor(evt);
-					this.showContextMenu(evt);
-					// doc.elementFromPoint(
-					// 	evt.clientX,
-					// 	evt.clientY,
-					// ).dispatchEvent(
-					// 	new MouseEvent('contextmenu', {
-					// 		bubbles: true,
-					// 		cancelable: true,
-					// 		clientX: evt.clientX,
-					// 		clientY: evt.clientY,
-					// 	}),
-					// );
-				}
-				this.currentGesture = null; // Reset gesture on mouse up
-				if (this.overlay) {
-					this.overlay.remove(); // Remove overlay when mouse is released
-				}
-			}
-		});
-	}
-	private startDrawing(evt: MouseEvent) {
-		// Check if drawing is enabled
-		if (!this.settings.enableDrawing) {
-			return; // Exit early if drawing is disabled
-		}
-
-		this.drawing = true;
-	
-		// Create a canvas if it doesn't exist
-		if (!this.canvas) {
-			this.canvas = document.createElement('canvas');
-			this.canvas.classList.add('gesture-canvas'); 
-	
-			this.canvas.width = window.innerWidth;
-			this.canvas.height = window.innerHeight;
-	
-			document.body.appendChild(this.canvas);
-			this.ctx = this.canvas.getContext('2d') as CanvasRenderingContext2D;
-	
-			let strokeColor = this.settings.strokeColor;
-			if (strokeColor === 'accent') {
-				const obsidianStyles = getComputedStyle(document.body);
-				strokeColor = obsidianStyles.getPropertyValue('--interactive-accent').trim();
-			} else if (strokeColor === 'custom') {
-				strokeColor = this.settings.customStrokeColor || '#000000'; // Fallback to black if custom color is not provided
-			}
-	
-			// Set the drawing style using the selected stroke color
-			if (this.ctx) {
-				this.ctx.strokeStyle = strokeColor;
-				this.ctx.lineWidth = this.settings.lineWidth;
-				this.ctx.lineJoin = 'round';
-				this.ctx.lineCap = 'round';
-			}
-		}
-	
-		// Begin path at the current mouse position
-		if (this.ctx) {
-			this.ctx.beginPath();
-			this.ctx.moveTo(evt.clientX, evt.clientY);
-		}
-	}
-	
-	// Draw the line to the current mouse position
-	private draw(x: number, y: number) {
-		if (!this.drawing || !this.settings.enableDrawing) {
-			return;
-		}
-		if (this.ctx) {
-			this.ctx.lineTo(x, y); // Draw line to this point
-			this.ctx.stroke(); // Actually render the line
-		}
-	}
-	
-	// Stop drawing and remove the canvas if necessary
-	private stopDrawing() {
-		if (!this.settings.enableDrawing) {
-			return; // Do nothing if drawing is disabled
-		}
-	
-		this.drawing = false;
-		if (this.canvas) {
-			document.body.removeChild(this.canvas);
-			this.canvas = null;
-			this.ctx = null;
-		}
-	}
-	
-	// Execute gesture actions and show the overlay
-	private executeGestureAction(
-		gesture: 'left' | 'right' | 'up' | 'down',
-		action: () => void,
-	) {
-		this.showGestureOverlay(gesture);
-		action();
-	}
-
-
-	private showContextMenu(evt: MouseEvent) {
-		const markdownView = this.getCurrentViewOfType();
-		if (isEditMode(markdownView)) {
-			this.showEditModeContextMenu(evt);
-		} else if (isPreviewMode(markdownView)) {
-			this.showPreviewContextMenu(evt);
-		}
-	}
-
-	private showEditModeContextMenu(evt: MouseEvent) {
-		const doc = document;
-		doc.elementFromPoint(evt.clientX, evt.clientY).dispatchEvent(
-			new MouseEvent('contextmenu', {
-				bubbles: true,
-				cancelable: true,
-				clientX: evt.clientX,
-				clientY: evt.clientY,
-			}),
-		);
-	}
-
-	private isSettingsVisible(): boolean {
-		const settingTabs = document.querySelector('.modal-container');
-		return settingTabs !== null && settingTabs.style.display !== 'none';
-	}
-
-	private selectTextUnderCursor(evt: MouseEvent) {
-		// TODO: Implement text selection under cursor
-	}	
-
-	private showPreviewContextMenu(evt: MouseEvent) {
-		// TODO: Implement original context menu in preview mode
-	}
-
-	private showGestureOverlay(gesture: 'left' | 'right' | 'up' | 'down') {
-		if (this.overlay) {
-			this.overlay.remove();
-		}
-	
-		this.overlay = document.createElement('div');
-		this.overlay.classList.add('gesture-overlay');
-	
-		let arrowSymbol = '';
-		let actionText = '';
-		if (gesture === 'right') {
-			arrowSymbol = '→'; // Right arrow
-			actionText = 'Next page';
-		} else if (gesture === 'left') {
-			arrowSymbol = '←'; // Left arrow
-			actionText = 'Previous page';
-		} else if (gesture === 'up') {
-			arrowSymbol = '↑'; // Up arrow
-			actionText = 'Scroll to top';
-		} else if (gesture === 'down') {
-			arrowSymbol = '↓'; // Down arrow
-			actionText = 'Scroll to bottom';
-		} else {
-			arrowSymbol = '✕'; // Cancel symbol
-			this.overlay.classList.add('gesture-overlay-cancel'); // Extra class for cancel symbol
-		}
-	
-		// Add the arrow symbol to the overlay
-		const arrow = document.createElement('div');
-		arrow.innerText = arrowSymbol;
-		this.overlay.appendChild(arrow);
-	
-		// Add text below the arrow based on gesture direction
-		const text = document.createElement('div');
-		text.innerText = actionText;
-		text.classList.add('gesture-text');
-		this.overlay.appendChild(text);
-	
-		document.body.appendChild(this.overlay);
-	}
-	
-
-	public getCurrentViewOfType() {
-		// get the current active view
-		let markdownView = this.app.workspace.getActiveViewOfType(MarkdownView);
-		// // To distinguish whether the current view is hidden or not markdownView
-		// const currentView = this.app.workspace.getActiveViewOfType(
-		// 	View,
-		// );
-		// // solve the problem of closing always focus new tab setting
-		// if (markdownView !== null) {
-		// 	globalMarkdownView = markdownView;
-		// } else {
-		// 	// fix the plugin shutdown problem when the current view is not exist
-		// 	if (currentView == null || !(currentView instanceof EditableFileView) && currentView?.file?.extension == 'md') {
-		// 		markdownView = globalMarkdownView;
-		// 	}
-		// }
-		return markdownView;
-	}
-
-	private scrollToTop() {
-		const markdownView = this.getCurrentViewOfType();
-		if (markdownView === null) return;
-		markdownView.currentMode.applyScroll(0);
-	}
-
-	private scrollToBottom = async () => {
-		const markdownView = this.getCurrentViewOfType();
-		if (markdownView === null) return;
-		markdownView.currentMode.applyScroll(Number.MAX_SAFE_INTEGER);
-	};
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
 }
 
-
 class GestureNavSettingTab extends PluginSettingTab {
-	plugin: GestureNav;
+  constructor(public app: App, private plugin: GestureNav) {
+    super(app, plugin);
+  }
 
-	constructor(app: App, plugin: GestureNav) {
-		super(app, plugin);
-		this.plugin = plugin;
-	}
-
-	display(): void {
-		const { containerEl } = this;
-
-		containerEl.empty();
-
-		new Setting(containerEl)
-			.setName('Triger mouse key')
-			.setDesc('Select the mouse key to trigger the gesture')
-			.addDropdown((dropdown) =>
-				dropdown
-					.addOptions({
-						[TrigerKey.RIGHT_CLICK]: 'Right click',
-						// [TrigerKey.WHEEL_CLICK]: 'Wheel click',
-					})
-					.setValue(this.plugin.settings.trigerkey)
-					.onChange(async (value) => {
-						this.plugin.settings.trigerkey = value as TrigerKey;
-						await this.plugin.saveSettings();
-					}),
-			);
-
-		// Drawing toggle
-		new Setting(containerEl)
-			.setName('Enable drawing')
-			.setDesc('Toggle to enable or disable gesture drawing on the screen')
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.enableDrawing)
-					.onChange(async (value) => {
-						this.plugin.settings.enableDrawing = value;
-						await this.plugin.saveSettings();
-					}),
-			);
-
-		// Stroke color settings
-		new Setting(containerEl)
-			.setName('Stroke color')
-			.setDesc('Select the color for the gesture stroke')
-			.addDropdown((dropdown) => {
-				dropdown
-					.addOptions({
-						'accent': 'Accent color',
-						'red': 'Red',
-						'orange': 'Orange',
-						'yellow': 'Yellow',
-						'green': 'Green',
-						'blue': 'Blue',
-						'purple': 'Purple',
-						'custom': 'Custom',
-					})
-					.setValue(this.plugin.settings.strokeColor || 'accent') // Default to accent
-					.onChange(async (value) => {
-						this.plugin.settings.strokeColor = value;
-						await this.plugin.saveSettings();
-
-						// Enable custom color input only if custom is selected
-						customColorSetting.setDisabled(value !== 'custom');
-					});
-			});
-
-		// Custom color input
-		const customColorSetting = new Setting(containerEl)
-			.setName('Custom stroke color')
-			.setDesc('Enter a custom color (hex or valid CSS color)')
-			.addText((text) =>
-				text
-					.setPlaceholder('#000000')
-					.setValue(this.plugin.settings.customStrokeColor || '')
-					.onChange(async (value) => {
-						this.plugin.settings.customStrokeColor = value;
-						await this.plugin.saveSettings();
-					}),
-			)
-			.setDisabled(this.plugin.settings.strokeColor !== 'custom'); // Disable unless custom is selected
-	
-		// Line width setting
-		new Setting(containerEl)
-			.setName('Line width')
-			.setDesc('Set the thickness of the gesture stroke')
-			.addSlider((slider) =>
-				slider
-					.setLimits(1, 10, 1) // Set range between 1 and 10
-					.setValue(this.plugin.settings.lineWidth)
-					.onChange(async (value) => {
-						this.plugin.settings.lineWidth = value;
-						await this.plugin.saveSettings();
-					}),
-			);
-	}
+  display(): void {
+    const { containerEl } = this;
+    (containerEl as HTMLElement).innerHTML = '';
+    new Setting(containerEl)
+      .setName('Trigger mouse key')
+      .setDesc('Select the mouse key to trigger the gesture')
+      .addDropdown((dropdown: any) =>
+        dropdown
+          .addOptions({ '2': 'Right click', '1': 'Wheel click' })
+          .setValue(String(this.plugin.settings.trigerkey))
+          .onChange(async (value: string) => {
+            this.plugin.settings.trigerkey = parseInt(value);
+            await this.plugin.saveSettings();
+          })
+      );
+    new Setting(containerEl)
+      .setName('Enable drawing')
+      .setDesc('Toggle gesture drawing')
+      .addToggle((toggle: any) =>
+        toggle
+          .setValue(this.plugin.settings.enableDrawing)
+          .onChange(async (value: boolean) => {
+            this.plugin.settings.enableDrawing = value;
+            await this.plugin.saveSettings();
+          })
+      );
+  }
 }

--- a/src/actions/ObsidianActions.ts
+++ b/src/actions/ObsidianActions.ts
@@ -1,0 +1,83 @@
+import { App, MarkdownView } from 'obsidian';
+
+export default class ObsidianActions {
+  constructor(private app: App) {}
+
+  nextPage() {
+    window.history.forward();
+  }
+
+  previousPage() {
+    window.history.back();
+  }
+
+  scrollToTop() {
+    const view = this.getMarkdownView();
+    view?.currentMode.applyScroll(0);
+  }
+
+  scrollToBottom() {
+    const view = this.getMarkdownView();
+    view?.currentMode.applyScroll(Number.MAX_SAFE_INTEGER);
+  }
+
+  cycleTabLeft() {
+    this.app.commands.executeCommandById('workspace:activate-previous-tab');
+  }
+
+  cycleTabRight() {
+    this.app.commands.executeCommandById('workspace:activate-next-tab');
+  }
+
+  closeTab() {
+    this.app.commands.executeCommandById('workspace:close-active-leaf');
+  }
+
+  newTab() {
+    this.app.commands.executeCommandById('workspace:new-tab');
+  }
+
+  minimizeWindow() {
+    this.app.commands.executeCommandById('app:minimize');
+  }
+
+  maximizeWindow() {
+    this.app.commands.executeCommandById('app:maximize');
+  }
+
+  nextSiblingFile() {
+    this.app.commands.executeCommandById('file-explorer:next-sibling');
+  }
+
+  previousSiblingFile() {
+    this.app.commands.executeCommandById('file-explorer:previous-sibling');
+  }
+
+  refresh() {
+    this.app.commands.executeCommandById('app:reload');
+  }
+
+  undo() {
+    this.app.commands.executeCommandById('editor:undo');
+  }
+
+  openSearch() {
+    this.app.commands.executeCommandById('app:open-search');
+  }
+
+  newWindow() {
+    this.app.commands.executeCommandById('window:new');
+  }
+
+  reopenClosedTab() {
+    this.app.commands.executeCommandById('workspace:open-closed-tab');
+  }
+
+  toggleFullScreen() {
+    this.app.commands.executeCommandById('window:toggle-fullscreen');
+  }
+
+  private getMarkdownView(): MarkdownView | null {
+    return this.app.workspace.getActiveViewOfType<MarkdownView>(null as any);
+  }
+}

--- a/src/gesture/GestureActionMap.ts
+++ b/src/gesture/GestureActionMap.ts
@@ -1,0 +1,54 @@
+import ObsidianActions from '../actions/ObsidianActions';
+import type { Gesture } from './GestureRecognizer';
+
+export default class GestureActionMap {
+  constructor(private actions: ObsidianActions) {}
+
+  execute(gesture: Gesture | null) {
+    if (!gesture) return;
+    switch (gesture) {
+      case 'left':
+        this.actions.nextPage();
+        break;
+      case 'right':
+        this.actions.previousPage();
+        break;
+      case 'up':
+        this.actions.scrollToTop();
+        break;
+      case 'down':
+        this.actions.scrollToBottom();
+        break;
+      case 'down+left':
+        this.actions.cycleTabLeft();
+        break;
+      case 'down+right':
+        this.actions.cycleTabRight();
+        break;
+      case 'up+left':
+        this.actions.closeTab();
+        break;
+      case 'up+right':
+        this.actions.newTab();
+        break;
+      case 'right+down':
+        this.actions.minimizeWindow();
+        break;
+      case 'right+up':
+        this.actions.maximizeWindow();
+        break;
+      case 'left+down':
+        this.actions.nextSiblingFile();
+        break;
+      case 'left+up':
+        this.actions.previousSiblingFile();
+        break;
+      case 'UD_REPEAT':
+        this.actions.refresh();
+        break;
+      case 'LR_REPEAT':
+        this.actions.undo();
+        break;
+    }
+  }
+}

--- a/src/gesture/GestureRecognizer.ts
+++ b/src/gesture/GestureRecognizer.ts
@@ -1,0 +1,54 @@
+export type SimpleDirection = 'left' | 'right' | 'up' | 'down';
+export type Gesture =
+  | SimpleDirection
+  | `${SimpleDirection}+${SimpleDirection}`
+  | 'UD_REPEAT'
+  | 'LR_REPEAT';
+
+export default class GestureRecognizer {
+  private directions: SimpleDirection[] = [];
+  private lastX = 0;
+  private lastY = 0;
+  private threshold = 75;
+
+  start(x: number, y: number) {
+    this.directions = [];
+    this.lastX = x;
+    this.lastY = y;
+  }
+
+  addPoint(x: number, y: number) {
+    const dx = x - this.lastX;
+    const dy = y - this.lastY;
+    let dir: SimpleDirection | null = null;
+    if (Math.abs(dx) > this.threshold && Math.abs(dy) < this.threshold) {
+      dir = dx > 0 ? 'right' : 'left';
+    } else if (Math.abs(dy) > this.threshold && Math.abs(dx) < this.threshold) {
+      dir = dy > 0 ? 'down' : 'up';
+    }
+    if (dir && this.directions[this.directions.length - 1] !== dir) {
+      this.directions.push(dir);
+      this.lastX = x;
+      this.lastY = y;
+    }
+  }
+
+  end(): Gesture | null {
+    if (this.directions.length === 0) return null;
+    if (this.isRepeat('up', 'down')) return 'UD_REPEAT';
+    if (this.isRepeat('left', 'right')) return 'LR_REPEAT';
+    if (this.directions.length === 1) return this.directions[0];
+    return `${this.directions[0]}+${this.directions[1]}` as Gesture;
+  }
+
+  private isRepeat(a: SimpleDirection, b: SimpleDirection): boolean {
+    if (this.directions.length < 4) return false;
+    for (let i = 0; i < this.directions.length; i++) {
+      const expected = i % 2 === 0 ? a : b;
+      const expectedAlt = i % 2 === 0 ? b : a;
+      if (this.directions[i] !== expected && this.directions[i] !== expectedAlt)
+        return false;
+    }
+    return true;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,10 +8,11 @@
 		"allowJs": true,
 		"noImplicitAny": true,
 		"moduleResolution": "node",
-		"importHelpers": true,
-		"isolatedModules": true,
-		"strictNullChecks": true,
-		"lib": ["DOM", "ES5", "ES6", "ES7"]
+        "importHelpers": false,
+        "isolatedModules": true,
+        "strictNullChecks": true,
+        "lib": ["DOM", "ES5", "ES6", "ES7"],
+        "typeRoots": ["./typings", "./node_modules/@types"]
 	},
 	"include": ["**/*.ts"]
 }

--- a/typings/obsidian.d.ts
+++ b/typings/obsidian.d.ts
@@ -1,0 +1,34 @@
+declare module 'obsidian' {
+  export interface App {
+    commands: {
+      executeCommandById(id: string): void;
+    };
+    workspace: {
+      getActiveViewOfType<T>(type: any): T | null;
+    };
+  }
+  export interface MarkdownView {
+    currentMode: {
+      applyScroll(pos: number): void;
+    };
+  }
+  export class Plugin {
+    app: App;
+    addSettingTab(tab: PluginSettingTab): void;
+    loadData(): Promise<any>;
+    saveData(data: any): Promise<void>;
+  }
+  export class PluginSettingTab {
+    app: App;
+    constructor(app: App, plugin: Plugin);
+    containerEl: HTMLElement;
+    display(): void;
+  }
+  export class Setting {
+    constructor(el: HTMLElement);
+    setName(name: string): this;
+    setDesc(desc: string): this;
+    addDropdown(cb: (drop: any) => any): this;
+    addToggle(cb: (toggle: any) => any): this;
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `GestureRecognizer` with support for directional combos and repeats
- implement `ObsidianActions` for default actions
- map gestures to actions in `GestureActionMap`
- simplify plugin and wire everything together
- provide stub definitions for the `obsidian` API so TypeScript can compile offline
- document new two-step gesture support

## Testing
- `npm run build` *(fails: Cannot find package 'esbuild')*
